### PR TITLE
Update cli.py

### DIFF
--- a/chatgpt/cli.py
+++ b/chatgpt/cli.py
@@ -100,7 +100,7 @@ def start(response_timeout: int = 20, user_agent: str | None = None):
             except httpx.ReadTimeout:
                 err_console.print(
                     "[bold red]Response timed out. ChatGPT may be overloaded, "
-                    "try to increase timeout using `--response_timeout` "
+                    "try to increase timeout using `--response-timeout` "
                     "argument.\nIf it won't help, try again later."
                 )
                 continue


### PR DESCRIPTION
Quickly fixed response_timeout to response-timeout. The actual option is --response-timeout. This is output by an error when using option: `--response_timeout`:
```
 Error ───────────────────────────────────────────────────────╮
│ No such option: --response_timeout Did you mean               │
│ --response-timeout? 
```